### PR TITLE
fix: freshen files was failing with exception, put in a fix for it

### DIFF
--- a/src/main/java/com/instaclustr/backup/uploader/IBMSnapshotUploader.java
+++ b/src/main/java/com/instaclustr/backup/uploader/IBMSnapshotUploader.java
@@ -59,7 +59,8 @@ public class IBMSnapshotUploader extends SnapshotUploader {
         final String canonicalPath = ((AWSRemoteObjectReference) object).canonicalPath;
 
         final CopyObjectRequest copyRequest = new CopyObjectRequest(restoreFromBackupBucket, canonicalPath, restoreFromBackupBucket, canonicalPath)
-                .withStorageClass(System.getenv("AWS_REGION") + "-standard");
+                .withStorageClass(System.getenv("AWS_REGION") + "-standard")
+                .withMetadataDirective("REPLACE");
 
         if (kmsId.isPresent()) {
             final SSEAwsKeyManagementParams params = new SSEAwsKeyManagementParams(kmsId.get());


### PR DESCRIPTION
Added the Metadata directive, this copies the whole object and updates the last modified timestamp of the file